### PR TITLE
Fix typo in live_demo.ipynb

### DIFF
--- a/notebooks/road_following/live_demo.ipynb
+++ b/notebooks/road_following/live_demo.ipynb
@@ -185,7 +185,7 @@
     "> Note: We have initialize the slider values for best known configurations, however these might not work for your dataset, therefore please increase or decrease the sliders according to your setup and environment\n",
     "\n",
     "1. Speed Control (speed_gain_slider): To start your JetBot increase ``speed_gain_slider`` \n",
-    "2. Steering Gain Control (steering_gain_sloder): If you see JetBot is woblling, you need to reduce ``steering_gain_slider`` till it is smooth\n",
+    "2. Steering Gain Control (steering_gain_slider): If you see JetBot is woblling, you need to reduce ``steering_gain_slider`` till it is smooth\n",
     "3. Steering Bias control (steering_bias_slider): If you see JetBot is biased towards extreme right or extreme left side of the track, you should control this slider till JetBot start following line or track in the center.  This accounts for motor biases as well as camera offsets\n",
     "\n",
     "> Note: You should play around above mentioned sliders with lower speed to get smooth JetBot road following behavior."
@@ -348,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Fix typo
from 'steering_gain_sloder` to `steering_gain_slider`