### PR TITLE
Collision Avoidance: Stop robot after initialisation

### DIFF
--- a/notebooks/collision_avoidance/live_demo.ipynb
+++ b/notebooks/collision_avoidance/live_demo.ipynb
@@ -196,7 +196,8 @@
     "    \n",
     "    time.sleep(0.001)\n",
     "        \n",
-    "update({'new': camera.value})  # we call the function once to intialize"
+    "update({'new': camera.value})  # we call the function once to intialize\n",
+    "robot.stop()  # camera is not attached yet\n"
    ]
   },
   {

--- a/notebooks/collision_avoidance/live_demo.ipynb
+++ b/notebooks/collision_avoidance/live_demo.ipynb
@@ -303,7 +303,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When execution function is initialised, camera is yet to be connected to the function, however
initialisation calls the function with the current image resulting in a runaway robot !

Furthermore, even if the operator completes camera attachment quickly, subsequent cell to stop the robot causes it to runaway is it has started twice.