### PR TITLE
Fix SSL error when loading pretrained model

### DIFF
--- a/notebooks/collision_avoidance/train_model.ipynb
+++ b/notebooks/collision_avoidance/train_model.ipynb
@@ -160,6 +160,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import ssl\n",
+    "ssl._create_default_https_context = ssl._create_unverified_context\n",
+    "\n",
     "model = models.alexnet(pretrained=True)"
    ]
   },
@@ -271,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When attempting to load the AlexNet model, I received the following error:
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed

Adding two lines of code fixed the issue.

This solution was suggested on
https://discuss.pytorch.org/t/torchvision-url-error-when-loading-pretrained-model/2544/8
