### PR TITLE
Add ResNet18 version notebooks and TensorRT live notebook for Collision Avoidance

### DIFF
--- a/notebooks/collision_avoidance/live_demo_resnet18.ipynb
+++ b/notebooks/collision_avoidance/live_demo_resnet18.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Collision Avoidance - Live Demo (Resnet18)\n",
+    "\n",
+    "In this notebook we'll use the model we trained to detect whether the robot is ``free`` or ``blocked`` to enable a collision avoidance behavior on the robot.  \n",
+    "\n",
+    "## Load the trained model\n",
+    "\n",
+    "We'll assumed that you've already downloaded the ``best_model.pth`` to your workstation as instructed in the training notebook.  Now, you should upload this model into this notebook's\n",
+    "directory by using the Jupyter Lab upload tool.  Once that's finished there should be a file named ``best_model.pth`` in this notebook's directory.  \n",
+    "\n",
+    "> Please make sure the file has uploaded fully before calling the next cell\n",
+    "\n",
+    "Execute the code below to initialize the PyTorch model.  This should look very familiar from the training notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue Jul 21 10:07:44 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torchvision\n",
+    "\n",
+    "model = torchvision.models.resnet18(pretrained=False)\n",
+    "model.fc = torch.nn.Linear(512, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, load the trained weights from the ``best_model.pth`` file that you uploaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.load_state_dict(torch.load('best_rn18_model.pth'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently, the model weights are located on the CPU memory execute the code below to transfer to the GPU device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda')\n",
+    "model = model.to(device)\n",
+    "model = model.eval().half()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the preprocessing function\n",
+    "\n",
+    "We have now loaded our model, but there's a slight issue.  The format that we trained our model doesnt *exactly* match the format of the camera.  To do that, \n",
+    "we need to do some *preprocessing*.  This involves the following steps\n",
+    "\n",
+    "1. Convert from BGR to RGB\n",
+    "2. Convert from HWC layout to CHW layout\n",
+    "3. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
+    "4. Transfer the data from CPU memory to GPU memory\n",
+    "5. Add a batch dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.transforms as transforms\n",
+    "import torch.nn.functional as F\n",
+    "import cv2\n",
+    "import PIL.Image\n",
+    "import numpy as np\n",
+    "\n",
+    "mean = torch.Tensor([0.485, 0.456, 0.406]).cuda().half()\n",
+    "std = torch.Tensor([0.229, 0.224, 0.225]).cuda().half()\n",
+    "\n",
+    "normalize = torchvision.transforms.Normalize(mean, std)\n",
+    "\n",
+    "def preprocess(image):\n",
+    "    image = PIL.Image.fromarray(image)\n",
+    "    image = transforms.functional.to_tensor(image).to(device).half()\n",
+    "    image.sub_(mean[:, None, None]).div_(std[:, None, None])\n",
+    "    return image[None, ...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! We've now defined our pre-processing function which can convert images from the camera format to the neural network input format.\n",
+    "\n",
+    "Now, let's start and display our camera.  You should be pretty familiar with this by now.  We'll also create a slider that will display the\n",
+    "probability that the robot is blocked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "af953b8b7ef94edcbd111dab8061d2ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x01\\x00\\x00\\xff\\xdb\\x00C…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import traitlets\n",
+    "from IPython.display import display\n",
+    "import ipywidgets.widgets as widgets\n",
+    "from jetbot import Camera, bgr8_to_jpeg\n",
+    "\n",
+    "camera = Camera.instance(width=224, height=224)\n",
+    "image = widgets.Image(format='jpeg', width=224, height=224)\n",
+    "blocked_slider = widgets.FloatSlider(description='blocked', min=0.0, max=1.0, orientation='vertical')\n",
+    "\n",
+    "camera_link = traitlets.dlink((camera, 'value'), (image, 'value'), transform=bgr8_to_jpeg)\n",
+    "\n",
+    "display(widgets.HBox([image, blocked_slider]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll also create our robot instance which we'll need to drive the motors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jetbot import Robot\n",
+    "\n",
+    "robot = Robot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll create a function that will get called whenever the camera's value changes.  This function will do the following steps\n",
+    "\n",
+    "1. Pre-process the camera image\n",
+    "2. Execute the neural network\n",
+    "3. While the neural network output indicates we're blocked, we'll turn left, otherwise we go forward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F\n",
+    "import time\n",
+    "\n",
+    "def update(change):\n",
+    "    global blocked_slider, robot\n",
+    "    x = change['new'] \n",
+    "    x = preprocess(x)\n",
+    "    y = model(x)\n",
+    "    #image = change['new']\n",
+    "    #y = model(preprocess(image)).detach().float().cpu().numpy().flatten()\n",
+    "    #print(y)\n",
+    "    \n",
+    "    # we apply the `softmax` function to normalize the output vector so it sums to 1 (which makes it a probability distribution)\n",
+    "    y = F.softmax(y, dim=1)\n",
+    "    #print(y)\n",
+    "    \n",
+    "    prob_blocked = float(y.flatten()[0])\n",
+    "    #print(prob_blocked)\n",
+    "    \n",
+    "    blocked_slider.value = prob_blocked\n",
+    "    \n",
+    "    if prob_blocked < 0.5:\n",
+    "        robot.forward(0.2)\n",
+    "    else:\n",
+    "        robot.left(0.2)\n",
+    "    \n",
+    "    time.sleep(0.001)\n",
+    "        \n",
+    "update({'new': camera.value})  # we call the function once to intialize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cool! We've created our neural network execution function, but now we need to attach it to the camera for processing. \n",
+    "\n",
+    "We accomplish that with the ``observe`` function.\n",
+    "\n",
+    "> WARNING: This code will move the robot!! Please make sure your robot has clearance.  The collision avoidance should work, but the neural\n",
+    "> network is only as good as the data it's trained on!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue Jul 21 10:08:41 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera.observe(update, names='value')  # this attaches the 'update' function to the 'value' traitlet of our camera"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Awesome! If your robot is plugged in it should now be generating new commands with each new camera frame.  Perhaps start by placing your robot on the ground and seeing what it does when it reaches an obstacle.\n",
+    "\n",
+    "If you want to stop this behavior, you can unattach this callback by executing the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "camera.unobserve(update, names='value')\n",
+    "\n",
+    "time.sleep(0.1)  # add a small sleep to make sure frames have finished processing\n",
+    "\n",
+    "robot.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perhaps you want the robot to run without streaming video to the browser.  You can unlink the camera as below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_link.unlink()  # don't stream to browser (will still run camera)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To continue streaming call the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_link.link()  # stream to browser (wont run camera)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "That's it for this live demo!  Hopefully you had some fun and your robot avoided collisions intelligently! \n",
+    "\n",
+    "If your robot wasn't avoiding collisions very well, try to spot where it fails.  The beauty is that we can collect more data for these failure scenarios\n",
+    "and the robot should get even better :)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/collision_avoidance/live_demo_resnet18.ipynb
+++ b/notebooks/collision_avoidance/live_demo_resnet18.ipynb
@@ -20,24 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tue Jul 21 10:07:44 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,27 +35,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, load the trained weights from the ``best_model.pth`` file that you uploaded"
+    "Next, load the trained weights from the ``best_model_resnet18.pth`` file that you uploaded"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<All keys matched successfully>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "model.load_state_dict(torch.load('best_rn18_model.pth'))"
+    "model.load_state_dict(torch.load('best_model_resnet18.pth'))"
    ]
   },
   {
@@ -84,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,16 +74,15 @@
     "We have now loaded our model, but there's a slight issue.  The format that we trained our model doesnt *exactly* match the format of the camera.  To do that, \n",
     "we need to do some *preprocessing*.  This involves the following steps\n",
     "\n",
-    "1. Convert from BGR to RGB\n",
-    "2. Convert from HWC layout to CHW layout\n",
-    "3. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
-    "4. Transfer the data from CPU memory to GPU memory\n",
-    "5. Add a batch dimension"
+    "1. Convert from HWC layout to CHW layout\n",
+    "2. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
+    "3. Transfer the data from CPU memory to GPU memory\n",
+    "4. Add a batch dimension"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,24 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "af953b8b7ef94edcbd111dab8061d2ed",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x01\\x00\\x00\\xff\\xdb\\x00C…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import traitlets\n",
     "from IPython.display import display\n",
@@ -187,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -223,16 +179,11 @@
     "    x = change['new'] \n",
     "    x = preprocess(x)\n",
     "    y = model(x)\n",
-    "    #image = change['new']\n",
-    "    #y = model(preprocess(image)).detach().float().cpu().numpy().flatten()\n",
-    "    #print(y)\n",
     "    \n",
     "    # we apply the `softmax` function to normalize the output vector so it sums to 1 (which makes it a probability distribution)\n",
     "    y = F.softmax(y, dim=1)\n",
-    "    #print(y)\n",
     "    \n",
     "    prob_blocked = float(y.flatten()[0])\n",
-    "    #print(prob_blocked)\n",
     "    \n",
     "    blocked_slider.value = prob_blocked\n",
     "    \n",
@@ -260,24 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tue Jul 21 10:08:41 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },

--- a/notebooks/collision_avoidance/live_demo_resnet18_trt.ipynb
+++ b/notebooks/collision_avoidance/live_demo_resnet18_trt.ipynb
@@ -20,24 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tue Jul 21 11:31:01 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,27 +36,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, load the trained weights from the ``best_model.pth`` file that you uploaded"
+    "Next, load the trained weights from the ``best_model_resnet18.pth`` file that you uploaded"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<All keys matched successfully>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "model.load_state_dict(torch.load('best_rn18_model.pth'))"
+    "model.load_state_dict(torch.load('best_model_resnet18.pth'))"
    ]
   },
   {
@@ -85,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +75,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> If your setup does not have `torch2trt` installed, you need to first install `torch2trt` by executing the following in the console.\n",
+    "```bash\n",
+    "cd $HOME\n",
+    "git clone https://github.com/NVIDIA-AI-IOT/torch2trt\n",
+    "cd torch2trt\n",
+    "sudo python3 setup.py install\n",
+    "```\n",
+    "\n",
     "Convert and optimize the model using torch2trt for faster inference with TensorRT. Please see the torch2trt readme for more details.\n",
     "\n",
     "> This optimization process can take a couple minutes to complete."
@@ -110,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,20 +126,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<All keys matched successfully>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import torch\n",
     "from torch2trt import TRTModule\n",
@@ -177,16 +146,15 @@
     "We have now loaded our model, but there's a slight issue.  The format that we trained our model doesnt *exactly* match the format of the camera.  To do that, \n",
     "we need to do some *preprocessing*.  This involves the following steps\n",
     "\n",
-    "1. Convert from BGR to RGB\n",
-    "2. Convert from HWC layout to CHW layout\n",
-    "3. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
-    "4. Transfer the data from CPU memory to GPU memory\n",
-    "5. Add a batch dimension"
+    "1. Convert from HWC layout to CHW layout\n",
+    "2. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
+    "3. Transfer the data from CPU memory to GPU memory\n",
+    "4. Add a batch dimension"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,24 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bba94fbaa165434c99cd224401d49ac0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x01\\x00\\x00\\xff\\xdb\\x00C…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import traitlets\n",
     "from IPython.display import display\n",
@@ -262,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -333,24 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tue Jul 21 11:36:15 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },

--- a/notebooks/collision_avoidance/live_demo_resnet18_trt.ipynb
+++ b/notebooks/collision_avoidance/live_demo_resnet18_trt.ipynb
@@ -1,0 +1,452 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Collision Avoidance - Live Demo (TensorRT)\n",
+    "\n",
+    "In this notebook we'll use the model we trained to detect whether the robot is ``free`` or ``blocked`` to enable a collision avoidance behavior on the robot.  \n",
+    "\n",
+    "## Load the trained model\n",
+    "\n",
+    "We'll assumed that you've already downloaded the ``best_model.pth`` to your workstation as instructed in the training notebook.  Now, you should upload this model into this notebook's\n",
+    "directory by using the Jupyter Lab upload tool.  Once that's finished there should be a file named ``best_model.pth`` in this notebook's directory.  \n",
+    "\n",
+    "> Please make sure the file has uploaded fully before calling the next cell\n",
+    "\n",
+    "Execute the code below to initialize the PyTorch model.  This should look very familiar from the training notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue Jul 21 11:31:01 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torchvision\n",
+    "\n",
+    "model = torchvision.models.resnet18(pretrained=False)\n",
+    "model.fc = torch.nn.Linear(512, 2)\n",
+    "model = model.cuda().eval().half()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, load the trained weights from the ``best_model.pth`` file that you uploaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.load_state_dict(torch.load('best_rn18_model.pth'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently, the model weights are located on the CPU memory execute the code below to transfer to the GPU device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TensorRT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert and optimize the model using torch2trt for faster inference with TensorRT. Please see the torch2trt readme for more details.\n",
+    "\n",
+    "> This optimization process can take a couple minutes to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch2trt import torch2trt\n",
+    "\n",
+    "data = torch.zeros((1, 3, 224, 224)).cuda().half()\n",
+    "\n",
+    "model_trt = torch2trt(model, [data], fp16_mode=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the optimized model using the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.save(model_trt.state_dict(), 'best_model_trt.pth')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the optimized model by executing the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from torch2trt import TRTModule\n",
+    "\n",
+    "model_trt = TRTModule()\n",
+    "model_trt.load_state_dict(torch.load('best_model_trt.pth'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the preprocessing function\n",
+    "\n",
+    "We have now loaded our model, but there's a slight issue.  The format that we trained our model doesnt *exactly* match the format of the camera.  To do that, \n",
+    "we need to do some *preprocessing*.  This involves the following steps\n",
+    "\n",
+    "1. Convert from BGR to RGB\n",
+    "2. Convert from HWC layout to CHW layout\n",
+    "3. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
+    "4. Transfer the data from CPU memory to GPU memory\n",
+    "5. Add a batch dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.transforms as transforms\n",
+    "import torch.nn.functional as F\n",
+    "import cv2\n",
+    "import PIL.Image\n",
+    "import numpy as np\n",
+    "\n",
+    "mean = torch.Tensor([0.485, 0.456, 0.406]).cuda().half()\n",
+    "std = torch.Tensor([0.229, 0.224, 0.225]).cuda().half()\n",
+    "\n",
+    "normalize = torchvision.transforms.Normalize(mean, std)\n",
+    "\n",
+    "def preprocess(image):\n",
+    "    image = PIL.Image.fromarray(image)\n",
+    "    image = transforms.functional.to_tensor(image).to(device).half()\n",
+    "    image.sub_(mean[:, None, None]).div_(std[:, None, None])\n",
+    "    return image[None, ...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! We've now defined our pre-processing function which can convert images from the camera format to the neural network input format.\n",
+    "\n",
+    "Now, let's start and display our camera.  You should be pretty familiar with this by now.  We'll also create a slider that will display the\n",
+    "probability that the robot is blocked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bba94fbaa165434c99cd224401d49ac0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x01\\x00\\x00\\xff\\xdb\\x00C…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import traitlets\n",
+    "from IPython.display import display\n",
+    "import ipywidgets.widgets as widgets\n",
+    "from jetbot import Camera, bgr8_to_jpeg\n",
+    "\n",
+    "camera = Camera.instance(width=224, height=224)\n",
+    "image = widgets.Image(format='jpeg', width=224, height=224)\n",
+    "blocked_slider = widgets.FloatSlider(description='blocked', min=0.0, max=1.0, orientation='vertical')\n",
+    "\n",
+    "camera_link = traitlets.dlink((camera, 'value'), (image, 'value'), transform=bgr8_to_jpeg)\n",
+    "\n",
+    "display(widgets.HBox([image, blocked_slider]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll also create our robot instance which we'll need to drive the motors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jetbot import Robot\n",
+    "\n",
+    "robot = Robot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll create a function that will get called whenever the camera's value changes.  This function will do the following steps\n",
+    "\n",
+    "1. Pre-process the camera image\n",
+    "2. Execute the neural network\n",
+    "3. While the neural network output indicates we're blocked, we'll turn left, otherwise we go forward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F\n",
+    "import time\n",
+    "\n",
+    "def update(change):\n",
+    "    global blocked_slider, robot\n",
+    "    x = change['new'] \n",
+    "    x = preprocess(x)\n",
+    "    y = model_trt(x)\n",
+    "    #print(y)\n",
+    "    \n",
+    "    # we apply the `softmax` function to normalize the output vector so it sums to 1 (which makes it a probability distribution)\n",
+    "    y = F.softmax(y, dim=1)\n",
+    "    #print(y)\n",
+    "    \n",
+    "    prob_blocked = float(y.flatten()[0])\n",
+    "    #print(prob_blocked)\n",
+    "    \n",
+    "    blocked_slider.value = prob_blocked\n",
+    "    \n",
+    "    if prob_blocked < 0.5:\n",
+    "        robot.forward(0.2)\n",
+    "    else:\n",
+    "        robot.left(0.2)\n",
+    "    \n",
+    "    time.sleep(0.001)\n",
+    "        \n",
+    "update({'new': camera.value})  # we call the function once to intialize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cool! We've created our neural network execution function, but now we need to attach it to the camera for processing. \n",
+    "\n",
+    "We accomplish that with the ``observe`` function.\n",
+    "\n",
+    "> WARNING: This code will move the robot!! Please make sure your robot has clearance.  The collision avoidance should work, but the neural\n",
+    "> network is only as good as the data it's trained on!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tue Jul 21 11:36:15 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera.observe(update, names='value')  # this attaches the 'update' function to the 'value' traitlet of our camera"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Awesome! If your robot is plugged in it should now be generating new commands with each new camera frame.  Perhaps start by placing your robot on the ground and seeing what it does when it reaches an obstacle.\n",
+    "\n",
+    "If you want to stop this behavior, you can unattach this callback by executing the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "camera.unobserve(update, names='value')\n",
+    "\n",
+    "time.sleep(0.1)  # add a small sleep to make sure frames have finished processing\n",
+    "\n",
+    "robot.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perhaps you want the robot to run without streaming video to the browser.  You can unlink the camera as below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_link.unlink()  # don't stream to browser (will still run camera)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To continue streaming call the following."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_link.link()  # stream to browser (wont run camera)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "That's it for this live demo!  Hopefully you had some fun and your robot avoided collisions intelligently! \n",
+    "\n",
+    "If your robot wasn't avoiding collisions very well, try to spot where it fails.  The beauty is that we can collect more data for these failure scenarios\n",
+    "and the robot should get even better :)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/collision_avoidance/train_model_resnet18.ipynb
+++ b/notebooks/collision_avoidance/train_model_resnet18.ipynb
@@ -1,0 +1,355 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Collision Avoidance - Train Model\n",
+    "\n",
+    "Welcome to this host side Jupyter Notebook!  This should look familiar if you ran through the notebooks that run on the robot.  In this notebook we'll train our image classifier to detect two classes\n",
+    "``free`` and ``blocked``, which we'll use for avoiding collisions.  For this, we'll use a popular deep learning library *PyTorch*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.optim as optim\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "import torchvision.datasets as datasets\n",
+    "import torchvision.models as models\n",
+    "import torchvision.transforms as transforms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload and extract dataset\n",
+    "\n",
+    "Before you start, you should upload the ``dataset.zip`` file that you created in the ``data_collection.ipynb`` notebook on the robot.\n",
+    "\n",
+    "You should then extract this dataset by calling the command below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!unzip -q dataset.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You should see a folder named ``dataset`` appear in the file browser."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create dataset instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we use the ``ImageFolder`` dataset class available with the ``torchvision.datasets`` package.  We attach transforms from the ``torchvision.transforms`` package to prepare the data for training.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = datasets.ImageFolder(\n",
+    "    'dataset',\n",
+    "    transforms.Compose([\n",
+    "        transforms.ColorJitter(0.1, 0.1, 0.1, 0.1),\n",
+    "        transforms.Resize((224, 224)),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])\n",
+    "    ])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Split dataset into train and test sets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we split the dataset into *training* and *test* sets.  The test set will be used to verify the accuracy of the model we train."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_dataset, test_dataset = torch.utils.data.random_split(dataset, [len(dataset) - 50, 50])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create data loaders to load data in batches"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll create two ``DataLoader`` instances, which provide utilities for shuffling data, producing *batches* of images, and loading the samples in parallel with multiple workers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loader = torch.utils.data.DataLoader(\n",
+    "    train_dataset,\n",
+    "    batch_size=16,\n",
+    "    shuffle=True,\n",
+    "    num_workers=1\n",
+    ")\n",
+    "\n",
+    "test_loader = torch.utils.data.DataLoader(\n",
+    "    test_dataset,\n",
+    "    batch_size=16,\n",
+    "    shuffle=True,\n",
+    "    num_workers=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define the neural network\n",
+    "\n",
+    "Now, we define the neural network we'll be training.  The *torchvision* package provides a collection of pre-trained models that we can use.\n",
+    "\n",
+    "In a process called *transfer learning*, we can repurpose a pre-trained model (trained on millions of images) for a new task that has possibly much less data available.\n",
+    "\n",
+    "Important features that were learned in the original training of the pre-trained model are re-usable for the new task.  We'll use the ``alexnet`` model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = models.resnet18(pretrained=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``alexnet`` model was originally trained for a dataset that had 1000 class labels, but our dataset only has two class labels!  We'll replace\n",
+    "the final layer with a new, untrained layer that has only two outputs.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#model.classifier[6] = torch.nn.Linear(model.classifier[6].in_features, 2)\n",
+    "model.fc = torch.nn.Linear(512, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we transfer our model for execution on the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda')\n",
+    "model = model.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train the neural network\n",
+    "\n",
+    "Using the code below we will train the neural network for 30 epochs, saving the best performing model after each epoch.\n",
+    "\n",
+    "> An epoch is a full run through our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Jul 20 12:30:50 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: 0.760000\n",
+      "1: 0.740000\n",
+      "2: 0.860000\n",
+      "3: 0.880000\n",
+      "4: 0.920000\n",
+      "5: 0.840000\n",
+      "6: 0.900000\n",
+      "7: 0.860000\n",
+      "8: 0.880000\n",
+      "9: 0.920000\n",
+      "10: 0.900000\n",
+      "11: 0.920000\n",
+      "12: 0.880000\n",
+      "13: 0.920000\n",
+      "14: 0.920000\n",
+      "15: 0.920000\n",
+      "16: 0.920000\n",
+      "17: 0.940000\n",
+      "18: 0.840000\n",
+      "19: 0.900000\n",
+      "20: 0.840000\n",
+      "21: 0.900000\n",
+      "22: 0.840000\n",
+      "23: 0.900000\n",
+      "24: 0.900000\n",
+      "25: 0.900000\n",
+      "26: 0.880000\n",
+      "27: 0.900000\n",
+      "28: 0.880000\n",
+      "29: 0.900000\n",
+      "CPU times: user 28.6 s, sys: 14 s, total: 42.6 s\n",
+      "Wall time: 6min 24s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "NUM_EPOCHS = 30\n",
+    "BEST_MODEL_PATH = 'best_rn18_model.pth'\n",
+    "best_accuracy = 0.0\n",
+    "\n",
+    "optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)\n",
+    "\n",
+    "for epoch in range(NUM_EPOCHS):\n",
+    "    \n",
+    "    for images, labels in iter(train_loader):\n",
+    "        images = images.to(device)\n",
+    "        labels = labels.to(device)\n",
+    "        optimizer.zero_grad()\n",
+    "        outputs = model(images)\n",
+    "        loss = F.cross_entropy(outputs, labels)\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "    \n",
+    "    test_error_count = 0.0\n",
+    "    for images, labels in iter(test_loader):\n",
+    "        images = images.to(device)\n",
+    "        labels = labels.to(device)\n",
+    "        outputs = model(images)\n",
+    "        test_error_count += float(torch.sum(torch.abs(labels - outputs.argmax(1))))\n",
+    "    \n",
+    "    test_accuracy = 1.0 - float(test_error_count) / float(len(test_dataset))\n",
+    "    print('%d: %f' % (epoch, test_accuracy))\n",
+    "    if test_accuracy > best_accuracy:\n",
+    "        torch.save(model.state_dict(), BEST_MODEL_PATH)\n",
+    "        best_accuracy = test_accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mon Jul 20 12:37:15 PDT 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "!date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once that is finished, you should see a file ``best_model.pth`` in the Jupyter Lab file browser.  Select ``Right click`` -> ``Download`` to download the model to your workstation"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/collision_avoidance/train_model_resnet18.ipynb
+++ b/notebooks/collision_avoidance/train_model_resnet18.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Collision Avoidance - Train Model\n",
+    "# Collision Avoidance - Train Model (ResNet18)\n",
     "\n",
     "Welcome to this host side Jupyter Notebook!  This should look familiar if you ran through the notebooks that run on the robot.  In this notebook we'll train our image classifier to detect two classes\n",
     "``free`` and ``blocked``, which we'll use for avoiding collisions.  For this, we'll use a popular deep learning library *PyTorch*"
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,11 +38,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!unzip -q dataset.zip"
+    "!unzip -q dataset.zip"
    ]
   },
   {
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,14 +130,14 @@
     "    train_dataset,\n",
     "    batch_size=16,\n",
     "    shuffle=True,\n",
-    "    num_workers=1\n",
+    "    num_workers=4\n",
     ")\n",
     "\n",
     "test_loader = torch.utils.data.DataLoader(\n",
     "    test_dataset,\n",
     "    batch_size=16,\n",
     "    shuffle=True,\n",
-    "    num_workers=1\n",
+    "    num_workers=4\n",
     ")"
    ]
   },
@@ -151,12 +151,12 @@
     "\n",
     "In a process called *transfer learning*, we can repurpose a pre-trained model (trained on millions of images) for a new task that has possibly much less data available.\n",
     "\n",
-    "Important features that were learned in the original training of the pre-trained model are re-usable for the new task.  We'll use the ``alexnet`` model."
+    "Important features that were learned in the original training of the pre-trained model are re-usable for the new task.  We'll use the ``resnet18`` model."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,17 +167,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``alexnet`` model was originally trained for a dataset that had 1000 class labels, but our dataset only has two class labels!  We'll replace\n",
+    "The ``resnet18`` model was originally trained for a dataset that had 1000 class labels, but our dataset only has two class labels!  We'll replace\n",
     "the final layer with a new, untrained layer that has only two outputs.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#model.classifier[6] = torch.nn.Linear(model.classifier[6].in_features, 2)\n",
     "model.fc = torch.nn.Linear(512, 2)"
    ]
   },
@@ -190,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,72 +210,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mon Jul 20 12:30:50 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0: 0.760000\n",
-      "1: 0.740000\n",
-      "2: 0.860000\n",
-      "3: 0.880000\n",
-      "4: 0.920000\n",
-      "5: 0.840000\n",
-      "6: 0.900000\n",
-      "7: 0.860000\n",
-      "8: 0.880000\n",
-      "9: 0.920000\n",
-      "10: 0.900000\n",
-      "11: 0.920000\n",
-      "12: 0.880000\n",
-      "13: 0.920000\n",
-      "14: 0.920000\n",
-      "15: 0.920000\n",
-      "16: 0.920000\n",
-      "17: 0.940000\n",
-      "18: 0.840000\n",
-      "19: 0.900000\n",
-      "20: 0.840000\n",
-      "21: 0.900000\n",
-      "22: 0.840000\n",
-      "23: 0.900000\n",
-      "24: 0.900000\n",
-      "25: 0.900000\n",
-      "26: 0.880000\n",
-      "27: 0.900000\n",
-      "28: 0.880000\n",
-      "29: 0.900000\n",
-      "CPU times: user 28.6 s, sys: 14 s, total: 42.6 s\n",
-      "Wall time: 6min 24s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%time\n",
-    "\n",
     "NUM_EPOCHS = 30\n",
-    "BEST_MODEL_PATH = 'best_rn18_model.pth'\n",
+    "BEST_MODEL_PATH = 'best_model_resnet18.pth'\n",
     "best_accuracy = 0.0\n",
     "\n",
     "optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)\n",
@@ -307,28 +248,18 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mon Jul 20 12:37:15 PDT 2020\n"
-     ]
-    }
-   ],
-   "source": [
-    "!date"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once that is finished, you should see a file ``best_model.pth`` in the Jupyter Lab file browser.  Select ``Right click`` -> ``Download`` to download the model to your workstation"
+    "Once that is finished, you should see a file ``best_model_resnet18.pth`` in the Jupyter Lab file browser.  Select ``Right click`` -> ``Download`` to download the model to your workstation"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/road_following/live_demo_trt.ipynb
+++ b/notebooks/road_following/live_demo_trt.ipynb
@@ -1,0 +1,570 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Road Following - Live demo (TensorRT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook, we will use model we trained to move jetBot smoothly on track. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Trained Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will assume that you have already downloaded ``best_steering_model_xy.pth`` to work station as instructed in \"train_model.ipynb\" notebook. Now, you should upload model file to JetBot in to this notebooks's directory. Once that's finished there should be a file named ``best_steering_model_xy.pth`` in this notebook's directory."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Please make sure the file has uploaded fully before calling the next cell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execute the code below to initialize the PyTorch model. This should look very familiar from the training notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision\n",
+    "import torch\n",
+    "\n",
+    "model = torchvision.models.resnet18(pretrained=False)\n",
+    "model.fc = torch.nn.Linear(512, 2)\n",
+    "model = model.cuda().eval().half()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, load the trained weights from the ``best_steering_model_xy.pth`` file that you uploaded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.load_state_dict(torch.load('best_steering_model_xy.pth'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently, the model weights are located on the CPU memory execute the code below to transfer to the GPU device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TensorRT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> If your setup does not have `torch2trt` installed, you need to first install `torch2trt` by executing the following in the console.\n",
+    "```bash\n",
+    "cd $HOME\n",
+    "git clone https://github.com/NVIDIA-AI-IOT/torch2trt\n",
+    "cd torch2trt\n",
+    "sudo python3 setup.py install\n",
+    "```\n",
+    "\n",
+    "Convert and optimize the model using torch2trt for faster inference with TensorRT. Please see the [torch2trt](https://github.com/NVIDIA-AI-IOT/torch2trt) readme for more details.\n",
+    "\n",
+    "> This optimization process can take a couple minutes to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch2trt import torch2trt\n",
+    "\n",
+    "data = torch.zeros((1, 3, 224, 224)).cuda().half()\n",
+    "\n",
+    "model_trt = torch2trt(model, [data], fp16_mode=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save the optimized model using the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.save(model_trt.state_dict(), 'best_steering_model_xy_trt.pth')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the optimized model by executing the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from torch2trt import TRTModule\n",
+    "\n",
+    "model_trt = TRTModule()\n",
+    "model_trt.load_state_dict(torch.load('best_steering_model_xy_trt.pth'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating the Pre-Processing Function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have now loaded our model, but there's a slight issue. The format that we trained our model doesnt exactly match the format of the camera. To do that, we need to do some preprocessing. This involves the following steps:\n",
+    "\n",
+    "1. Convert from HWC layout to CHW layout\n",
+    "2. Normalize using same parameters as we did during training (our camera provides values in [0, 255] range and training loaded images in [0, 1] range so we need to scale by 255.0\n",
+    "3. Transfer the data from CPU memory to GPU memory\n",
+    "4. Add a batch dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.transforms as transforms\n",
+    "import torch.nn.functional as F\n",
+    "import cv2\n",
+    "import PIL.Image\n",
+    "import numpy as np\n",
+    "\n",
+    "mean = torch.Tensor([0.485, 0.456, 0.406]).cuda().half()\n",
+    "std = torch.Tensor([0.229, 0.224, 0.225]).cuda().half()\n",
+    "\n",
+    "def preprocess(image):\n",
+    "    image = PIL.Image.fromarray(image)\n",
+    "    image = transforms.functional.to_tensor(image).to(device).half()\n",
+    "    image.sub_(mean[:, None, None]).div_(std[:, None, None])\n",
+    "    return image[None, ...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Awesome! We've now defined our pre-processing function which can convert images from the camera format to the neural network input format.\n",
+    "\n",
+    "Now, let's start and display our camera. You should be pretty familiar with this by now. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2a065eb6d4c8445a84855af48d060529",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Image(value=b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x01\\x00\\x00\\xff\\xdb\\x00C\\x00\\x02\\x01\\x0…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display\n",
+    "import ipywidgets\n",
+    "import traitlets\n",
+    "from jetbot import Camera, bgr8_to_jpeg\n",
+    "\n",
+    "camera = Camera()\n",
+    "\n",
+    "image_widget = ipywidgets.Image()\n",
+    "\n",
+    "traitlets.dlink((camera, 'value'), (image_widget, 'value'), transform=bgr8_to_jpeg)\n",
+    "\n",
+    "display(image_widget)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll also create our robot instance which we'll need to drive the motors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jetbot import Robot\n",
+    "\n",
+    "robot = Robot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we will define sliders to control JetBot\n",
+    "> Note: We have initialize the slider values for best known configurations, however these might not work for your dataset, therefore please increase or decrease the sliders according to your setup and environment\n",
+    "\n",
+    "1. Speed Control (speed_gain_slider): To start your JetBot increase ``speed_gain_slider`` \n",
+    "2. Steering Gain Control (steering_gain_sloder): If you see JetBot is woblling, you need to reduce ``steering_gain_slider`` till it is smooth\n",
+    "3. Steering Bias control (steering_bias_slider): If you see JetBot is biased towards extreme right or extreme left side of the track, you should control this slider till JetBot start following line or track in the center.  This accounts for motor biases as well as camera offsets\n",
+    "\n",
+    "> Note: You should play around above mentioned sliders with lower speed to get smooth JetBot road following behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "15db4f18667d4c8ea82c1c0d9fcbadfa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, description='speed gain', max=1.0, step=0.01)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ab5664157a564110aa7e5c019954ce4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.2, description='steering gain', max=1.0, step=0.01)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "594a7000dbb24458a3586fffd28acf43",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, description='steering kd', max=0.5, step=0.001)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31b253fdaa324bbf883d426443f779a4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, description='steering bias', max=0.3, min=-0.3, step=0.01)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "speed_gain_slider = ipywidgets.FloatSlider(min=0.0, max=1.0, step=0.01, description='speed gain')\n",
+    "steering_gain_slider = ipywidgets.FloatSlider(min=0.0, max=1.0, step=0.01, value=0.2, description='steering gain')\n",
+    "steering_dgain_slider = ipywidgets.FloatSlider(min=0.0, max=0.5, step=0.001, value=0.0, description='steering kd')\n",
+    "steering_bias_slider = ipywidgets.FloatSlider(min=-0.3, max=0.3, step=0.01, value=0.0, description='steering bias')\n",
+    "\n",
+    "display(speed_gain_slider, steering_gain_slider, steering_dgain_slider, steering_bias_slider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's display some sliders that will let us see what JetBot is thinking.  The x and y sliders will display the predicted x, y values.\n",
+    "\n",
+    "The steering slider will display our estimated steering value.  Please remember, this value isn't the actual angle of the target, but simply a value that is\n",
+    "nearly proportional.  When the actual angle is ``0``, this will be zero, and it will increase / decrease with the actual angle.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4906b622c7954554b41123023df8bdab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatSlider(value=0.0, description='y', max=1.0, orientation='vertical'), FloatSlider(value=0.0…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13f63ca30b97428ba6421918760d663f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, description='x', max=1.0, min=-1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "456da896ff354ff184cc98bbb2f804b0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, description='steering', max=1.0, min=-1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x_slider = ipywidgets.FloatSlider(min=-1.0, max=1.0, description='x')\n",
+    "y_slider = ipywidgets.FloatSlider(min=0, max=1.0, orientation='vertical', description='y')\n",
+    "steering_slider = ipywidgets.FloatSlider(min=-1.0, max=1.0, description='steering')\n",
+    "speed_slider = ipywidgets.FloatSlider(min=0, max=1.0, orientation='vertical', description='speed')\n",
+    "\n",
+    "display(ipywidgets.HBox([y_slider, speed_slider]))\n",
+    "display(x_slider, steering_slider)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll create a function that will get called whenever the camera's value changes. This function will do the following steps\n",
+    "\n",
+    "1. Pre-process the camera image\n",
+    "2. Execute the neural network\n",
+    "3. Compute the approximate steering value\n",
+    "4. Control the motors using proportional / derivative control (PD)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "angle = 0.0\n",
+    "angle_last = 0.0\n",
+    "\n",
+    "def execute(change):\n",
+    "    global angle, angle_last\n",
+    "    image = change['new']\n",
+    "    xy = model_trt(preprocess(image)).detach().float().cpu().numpy().flatten()\n",
+    "    x = xy[0]\n",
+    "    y = (0.5 - xy[1]) / 2.0\n",
+    "    \n",
+    "    x_slider.value = x\n",
+    "    y_slider.value = y\n",
+    "    \n",
+    "    speed_slider.value = speed_gain_slider.value\n",
+    "    \n",
+    "    angle = np.arctan2(x, y)\n",
+    "    pid = angle * steering_gain_slider.value + (angle - angle_last) * steering_dgain_slider.value\n",
+    "    angle_last = angle\n",
+    "    \n",
+    "    steering_slider.value = pid + steering_bias_slider.value\n",
+    "    \n",
+    "    robot.left_motor.value = max(min(speed_slider.value + steering_slider.value, 1.0), 0.0)\n",
+    "    robot.right_motor.value = max(min(speed_slider.value - steering_slider.value, 1.0), 0.0)\n",
+    "    \n",
+    "execute({'new': camera.value})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cool! We've created our neural network execution function, but now we need to attach it to the camera for processing.\n",
+    "\n",
+    "We accomplish that with the observe function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ">WARNING: This code will move the robot!! Please make sure your robot has clearance and it is on Lego or Track you have collected data on. The road follower should work, but the neural network is only as good as the data it's trained on!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera.observe(execute, names='value')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Awesome! If your robot is plugged in it should now be generating new commands with each new camera frame. \n",
+    "\n",
+    "You can now place JetBot on  Lego or Track you have collected data on and see whether it can follow track.\n",
+    "\n",
+    "If you want to stop this behavior, you can unattach this callback by executing the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "camera.unobserve(execute, names='value')\n",
+    "\n",
+    "time.sleep(0.1)  # add a small sleep to make sure frames have finished processing\n",
+    "\n",
+    "robot.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "That's it for this live demo! Hopefully you had some fun seeing your JetBot moving smoothly on track follwing the road!!!\n",
+    "\n",
+    "If your JetBot wasn't following road very well, try to spot where it fails. The beauty is that we can collect more data for these failure scenarios and the JetBot should get even better :)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Added the following;
- `notebook/collsion_avoidance/train_model_resnet18.ipynb`
- `notebook/collsion_avoidance/live_demo_resnet18.ipynb`
- `notebook/collsion_avoidance/live_demo_resnet18_trt.ipynb`

Verified on 
- JetBot v0p4p0 image
- JetPack 4.4dp based image (setup script [here](https://github.com/NVIDIA-AI-IOT/jetbot/blob/jetpack_4.4dp/scripts/create-sdcard-image-from-scratch.sh))

Remark(s)
- The framerate on `live_demo_resnet18.ipynb` appears little low than the original and the TRT version