### PR TITLE
added camera widget convenience helper

### DIFF
--- a/jetbot/camera/camera.py
+++ b/jetbot/camera/camera.py
@@ -16,3 +16,13 @@ class Camera(traitlets.HasTraits):
     @staticmethod
     def instance(*args, **kwargs):
         return Camera.default_camera_class()(*args, **kwargs)
+    
+    def widget(self):
+        if hasattr(self, '_widget'):
+            return self._widget   # cache widget, so we don't duplicate links
+        from ipywidgets import Image
+        from jetbot.image import bgr8_to_jpeg
+        image = Image()
+        traitlets.dlink((self, 'value'), (image, 'value'), transform=bgr8_to_jpeg)
+        self._widget = image
+        return image


### PR DESCRIPTION
Constantly having to type this boilerplate is annoying

```python
import ipywidgets
from jetbot.image import bgr8_to_jpeg

image = ipywidgets.Image()

traitlets.dlink((camera, 'value'), (image, 'value'), transform=bgr8_to_jpeg)

display(image)
```

This PR adds the ``camera.widget()`` method which abstracts this.

```python
display(camera.widget())
```