### PR TITLE
docker version select, memory, push

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,21 +4,59 @@ This directory contains scripts to build the JetBot docker containers.
 
 ## Quick Start
 
-### Step 1 - Build All Containers
+### Step 1 - Configure System
+
+First, call the ``scripts/configure_jetson.sh`` script to configure the power mode and other parameters.
+
+```bash
+cd jetbot
+./scripts/configure_jetson.sh
+```
+
+Next, source the ``docker/configure.sh`` script to configure various environment variables related to JetBot docker.
 
 ```bash
 cd docker
-./build.sh
+source configure.sh
+```
+
+Finally, if you haven't already, set the default docker runtime to NVIDIA.  This is needed to use
+CUDA related components with the containers.
+
+```bash
+./set_nvidia_runtime.sh
+```
+
+If needed, you can also set memory limits on the Jupyter container.
+
+```bash
+export JETBOT_JUPYTER_MEMORY=500m
+export JETBOT_JUPYTER_MEMORY_SWAP=3G
 ```
 
 ### Step 2 - Enable all containers
+
+Call the following to enable the JetBot docker containers 
 
 ```bash
 sudo systemctl enable docker   # enable docker daemon at boot
 ./enable.sh $HOME   # we'll use home directory as working directory, set this as you please.
 ```
 
-Now you can go to ``https://<jetbot_ip>:8888`` and start programming JetBot from your web browser.
-The directory you specify to ``./run.sh`` will be mounted as a volume in the jupyter container 
+Now you can go to ``https://<jetbot_ip>:8888`` from a web browser and start programming JetBot!
+You can do this from any machine on your local network.  The password to log in is ``jetbot``.
+
+![](https://user-images.githubusercontent.com/25759564/92091965-51ae4f00-ed86-11ea-93d5-09d291ccfa95.png)
+
+
+> Note: The directory you specify to ``./enable.sh`` will be mounted as a volume in the jupyter container 
 at the location ``/workspace``.  This means the work you in the ``/workspace`` folder inside container
-is saved.  Please note, if you work outside of that directory it will be lost when the container shuts down.
+is saved.  This is set to the root directory of Jupyter Lab.  Please note, if you work outside of that directory it will be lost when the container shuts down.
+
+## Building Containers
+
+If you want to build the containers from scratch, simply call
+
+```bash
+./build.sh
+```

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -10,7 +10,7 @@ fi
 
 sudo docker build \
     --build-arg BASE_IMAGE=$BASE_IMAGE \
-    -t jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile \
     ../..  # jetbot repo root as context
 

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -10,7 +10,7 @@ fi
 
 sudo docker build \
     --build-arg BASE_IMAGE=$BASE_IMAGE \
-    -t jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t $JETBOT_DOCKER_REMOTE/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile \
     ../..  # jetbot repo root as context
 

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -1,7 +1,16 @@
 cp /etc/apt/trusted.gpg.d/jetson-ota-public.asc ../.. # copy to jetbot root
 
+if [[ "$L4T_VERSION" == "32.4.3" ]]
+then
+    BASE_IMAGE=nvcr.io/nvidia/l4t-pytorch:r32.4.3-pth1.6-py3
+elif [[ "$L4T_VERSION" == "32.4.4" ]]
+then
+    BASE_IMAGE=nvcr.io/ea-linux4tegra/l4t-pytorch:r32.4.4-pth1.6-py3
+fi
+
 sudo docker build \
-    -t jetbot-base:$JETBOT_VERSION \
+    --build-arg BASE_IMAGE=$BASE_IMAGE \
+    -t jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile \
     ../..  # jetbot repo root as context
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,3 @@
-export JETBOT_VERSION=jp44
-
 cd base && ./build.sh && cd ..
 cd models && ./build.sh && cd ..
 cd display && ./build.sh && cd ..

--- a/docker/camera/build.sh
+++ b/docker/camera/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=$JETBOT_DOCKER_REMOTE/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t $JETBOT_DOCKER_REMOTE/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/camera/build.sh
+++ b/docker/camera/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot-base:$JETBOT_VERSION \
-    -t jetbot-camera:$JETBOT_VERSION \
+    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot:camera-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/camera/build.sh
+++ b/docker/camera/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot:camera-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/camera/enable.sh
+++ b/docker/camera/enable.sh
@@ -10,4 +10,4 @@ sudo docker run -it -d \
     --volume /tmp/argus_socket:/tmp/argus_socket \
     --privileged \
     --name=jetbot_camera \
-    jetbot-camera:$JETBOT_VERSION
+    jetbot:camera-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/camera/enable.sh
+++ b/docker/camera/enable.sh
@@ -10,4 +10,4 @@ sudo docker run -it -d \
     --volume /tmp/argus_socket:/tmp/argus_socket \
     --privileged \
     --name=jetbot_camera \
-    jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION
+    $JETBOT_DOCKER_REMOTE/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/camera/enable.sh
+++ b/docker/camera/enable.sh
@@ -10,4 +10,4 @@ sudo docker run -it -d \
     --volume /tmp/argus_socket:/tmp/argus_socket \
     --privileged \
     --name=jetbot_camera \
-    jetbot:camera-$JETBOT_VERSION-$L4T_VERSION
+    jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export L4T_VERSION=32.4.3
+export JETBOT_VERSION=0.4.0
+
+

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
-export L4T_VERSION=32.4.3
-export JETBOT_VERSION=0.4.0
+export JETBOT_VERSION=0.4.1
+
+L4T_VERSION_STRING=$(head -n 1 /etc/nv_tegra_release)
+L4T_RELEASE=$(echo $L4T_VERSION_STRING | cut -f 2 -d ' ' | grep -Po '(?<=R)[^;]+')
+L4T_REVISION=$(echo $L4T_VERSION_STRING | cut -f 2 -d ',' | grep -Po '(?<=REVISION: )[^;]+')
+
+export L4T_VERSION="$L4T_RELEASE.$L4T_REVISION"
+
+if [[ "$L4T_VERSION" == "32.4.3" ]]
+then
+    # docker hub
+    export JETBOT_DOCKER_REMOTE=jetbot
+elif [[ "$L4T_VERSION" == "32.4.4" ]]
+then
+    export JETBOT_DOCKER_REMOTE=nvcr.io/ea-linux4tegra
+fi
 
 

--- a/docker/display/build.sh
+++ b/docker/display/build.sh
@@ -1,5 +1,5 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot:display-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .
 

--- a/docker/display/build.sh
+++ b/docker/display/build.sh
@@ -1,5 +1,5 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot-base:$JETBOT_VERSION \
-    -t jetbot-display:$JETBOT_VERSION \
+    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot:display-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .
 

--- a/docker/display/build.sh
+++ b/docker/display/build.sh
@@ -1,5 +1,5 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=$JETBOT_DOCKER_REMOTE/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t $JETBOT_DOCKER_REMOTE/jetbot:display-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .
 

--- a/docker/display/enable.sh
+++ b/docker/display/enable.sh
@@ -4,4 +4,4 @@ sudo docker run -it -d \
     --network host \
     --privileged \
     --name=jetbot_display \
-    jetbot-display:$JETBOT_VERSION
+    jetbot:display-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/display/enable.sh
+++ b/docker/display/enable.sh
@@ -4,4 +4,4 @@ sudo docker run -it -d \
     --network host \
     --privileged \
     --name=jetbot_display \
-    jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION
+    $JETBOT_DOCKER_REMOTE/jetbot:display-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/display/enable.sh
+++ b/docker/display/enable.sh
@@ -4,4 +4,4 @@ sudo docker run -it -d \
     --network host \
     --privileged \
     --name=jetbot_display \
-    jetbot:display-$JETBOT_VERSION-$L4T_VERSION
+    jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/enable.sh
+++ b/docker/enable.sh
@@ -1,5 +1,3 @@
-export JETBOT_VERSION=jp44
-
 JUPYTER_WORKSPACE=${1:-$HOME}  # default to $HOME
 JETBOT_CAMERA=${2:-opencv_gst_camera}  # default to opencv
 

--- a/docker/jupyter/build.sh
+++ b/docker/jupyter/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=jetbot/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/jupyter/build.sh
+++ b/docker/jupyter/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=$JETBOT_DOCKER_REMOTE/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
+    -t $JETBOT_DOCKER_REMOTE/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/jupyter/build.sh
+++ b/docker/jupyter/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot-models:$JETBOT_VERSION \
-    -t jetbot-jupyter:$JETBOT_VERSION \
+    --build-arg BASE_IMAGE=jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/jupyter/enable.sh
+++ b/docker/jupyter/enable.sh
@@ -14,4 +14,4 @@ sudo docker run -it -d \
     --workdir /workspace \
     --name=jetbot_jupyter \
     --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
-    jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/jupyter/enable.sh
+++ b/docker/jupyter/enable.sh
@@ -24,7 +24,7 @@ then
 	    --name=jetbot_jupyter \
 	    --memory-swap=$JETBOT_JUPYTER_MEMORY_SWAP \
 	    --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
-	    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+	    $JETBOT_DOCKER_REMOTE/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
 
 else
 
@@ -43,6 +43,6 @@ else
 	    --memory=$JETBOT_JUPYTER_MEMORY \
 	    --memory-swap=$JETBOT_JUPYTER_MEMORY_SWAP \
 	    --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
-	    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+	    $JETBOT_DOCKER_REMOTE/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
 
 fi

--- a/docker/jupyter/enable.sh
+++ b/docker/jupyter/enable.sh
@@ -1,17 +1,48 @@
 WORKSPACE=$1
 JETBOT_CAMERA={$2:-opencv_gst_camera}
 
-sudo docker run -it -d \
-    --restart always \
-    --runtime nvidia \
-    --network host \
-    --privileged \
-    --device /dev/video* \
-    --volume /dev/bus/usb:/dev/bus/usb \
-    --volume /tmp/argus_socket:/tmp/argus_socket \
-    -p 8888:8888 \
-    -v $WORKSPACE:/workspace \
-    --workdir /workspace \
-    --name=jetbot_jupyter \
-    --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
-    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+# set default swap limit as unlimited
+if [[ -z "$JETBOT_JUPYTER_MEMORY_SWAP" ]]
+then
+	export JETBOT_JUPYTER_MEMORY_SWAP=-1
+fi
+
+if [[ -z "$JETBOT_JUPYTER_MEMORY" ]]
+then
+
+	sudo docker run -it -d \
+	    --restart always \
+	    --runtime nvidia \
+	    --network host \
+	    --privileged \
+	    --device /dev/video* \
+	    --volume /dev/bus/usb:/dev/bus/usb \
+	    --volume /tmp/argus_socket:/tmp/argus_socket \
+	    -p 8888:8888 \
+	    -v $WORKSPACE:/workspace \
+	    --workdir /workspace \
+	    --name=jetbot_jupyter \
+	    --memory-swap=$JETBOT_JUPYTER_MEMORY_SWAP \
+	    --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
+	    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+
+else
+
+	sudo docker run -it -d \
+	    --restart always \
+	    --runtime nvidia \
+	    --network host \
+	    --privileged \
+	    --device /dev/video* \
+	    --volume /dev/bus/usb:/dev/bus/usb \
+	    --volume /tmp/argus_socket:/tmp/argus_socket \
+	    -p 8888:8888 \
+	    -v $WORKSPACE:/workspace \
+	    --workdir /workspace \
+	    --name=jetbot_jupyter \
+	    --memory=$JETBOT_JUPYTER_MEMORY \
+	    --memory-swap=$JETBOT_JUPYTER_MEMORY_SWAP \
+	    --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
+	    jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+
+fi

--- a/docker/jupyter/enable.sh
+++ b/docker/jupyter/enable.sh
@@ -14,4 +14,4 @@ sudo docker run -it -d \
     --workdir /workspace \
     --name=jetbot_jupyter \
     --env JETBOT_DEFAULT_CAMERA=$JETBOT_CAMERA \
-    jetbot-jupyter:$JETBOT_VERSION
+    jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/models/build.sh
+++ b/docker/models/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot-base:$JETBOT_VERSION \
-    -t jetbot-models:$JETBOT_VERSION \
+    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/models/build.sh
+++ b/docker/models/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=$JETBOT_DOCKER_REMOTE/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t $JETBOT_DOCKER_REMOTE/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/models/build.sh
+++ b/docker/models/build.sh
@@ -1,4 +1,4 @@
 sudo docker build \
-    --build-arg BASE_IMAGE=jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
-    -t jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
+    --build-arg BASE_IMAGE=jetbot/jetbot:base-$JETBOT_VERSION-$L4T_VERSION \
+    -t jetbot/jetbot:models-$JETBOT_VERSION-$L4T_VERSION \
     -f Dockerfile .

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo docker push jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION
+sudo docker push jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+sudo docker push jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo docker push jetbot/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION
-sudo docker push jetbot/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
-sudo docker push jetbot/jetbot:display-$JETBOT_VERSION-$L4T_VERSION
+sudo docker push $JETBOT_DOCKER_REMOTE/jetbot:camera-$JETBOT_VERSION-$L4T_VERSION
+sudo docker push $JETBOT_DOCKER_REMOTE/jetbot:jupyter-$JETBOT_VERSION-$L4T_VERSION
+sudo docker push $JETBOT_DOCKER_REMOTE/jetbot:display-$JETBOT_VERSION-$L4T_VERSION

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ build_libs()
 
 setup(
     name='jetbot',
-    version='0.4.0',
+    version='0.4.1',
     description='An open-source robot based on NVIDIA Jetson Nano',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
# Configure

These need to be thrown in a script eventually, could probably automatically be determined.

```bash
cd docker
export JETBOT_VERSION=0.4.0
export L4T_VERSION=32.4.3
export JETBOT_JUPYTER_MEMORY=500m  # don't define for unlimited
export JETBOT_JUPYTER_MEMORY_SWAP=3G
```

Container names are ``jetbot/jetbot:<type>-<jetbot version>-<l4t version>``.  For example,
``jetbot/jetbot:jupyter-0.4.0-32.4.3``.

# Run

After configuring, just call.  It will pull from docker hub if version matching has been pushed.

```bash
./enable.sh $HOME
```

# Build

To re-build locally, just call.

```bash
./build.sh
```

# Push

If you have rights, you can push to docker hub.

```bash
./push.sh
```