### PR TITLE
Preinstall SSH client, so one can log back into the Docker host

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -5,6 +5,9 @@ ARG JUPYTER_PASSWORD=jetbot
 ENV JUPYTER_WORKDIR=/workspace
 WORKDIR /workspace
 
+RUN apt-get update && \
+    apt-get install -y ssh
+
 # ====================
 # SET JUPYTER PASSWORD
 # ====================


### PR DESCRIPTION
This would enable users to execute commands like `nvpmodel`, `tegrastats` and `reboot` from Jupyter Lab Terminal, by SSH back into the Docker host.