### PR TITLE
Corrected typo which identified the function "backward" as "backwards" and add Waveshare specific comments

### DIFF
--- a/jetbot/motor.py
+++ b/jetbot/motor.py
@@ -36,15 +36,18 @@ class Motor(Configurable):
         self._motor.setSpeed(speed)
         if mapped_value < 0:
             self._motor.run(Adafruit_MotorHAT.FORWARD)
+            # The two lines below are required for the Waveshare JetBot Board only
             self._driver._pwm.setPWM(self._ina,0,0)
             self._driver._pwm.setPWM(self._inb,0,speed*16)
         else:
             self._motor.run(Adafruit_MotorHAT.BACKWARD)
+            # The two lines below are required for the Waveshare JetBot Board only
             self._driver._pwm.setPWM(self._ina,0,speed*16)
             self._driver._pwm.setPWM(self._inb,0,0)
 
     def _release(self):
         """Stops motor by releasing control"""
         self._motor.run(Adafruit_MotorHAT.RELEASE)
+        # The two lines below are required for the Waveshare JetBot Board only
         self._driver._pwm.setPWM(self._ina,0,0)
         self._driver._pwm.setPWM(self._inb,0,0)

--- a/notebooks/basic_motion/basic_motion.ipynb
+++ b/notebooks/basic_motion/basic_motion.ipynb
@@ -146,7 +146,7 @@
     "> us to set function parameters by either their name, or the order that they are defined\n",
     "> (without specifying the name).\n",
     "\n",
-    "The ``BasicJetbot`` class also has the methods ``right``, ``forward``, and ``backwards``.  Try creating your own cell to make\n",
+    "The ``BasicJetbot`` class also has the methods ``right``, ``forward``, and ``backward``.  Try creating your own cell to make\n",
     "the robot move forward at 50% speed for one second.\n",
     "\n",
     "Create a new cell by highlighting an existing cell and pressing ``b`` or the ``+`` icon above.  Once you've done that, type in the code that you think will make the robot move forward at 50% speed for one second."


### PR DESCRIPTION
There is a minor typo in the basic_motion notebook which could trip up users. The documentation referred to the function "backward" as "backwards". If the user tried to follow the documentation and include the "s" they would get an error.