### PR TITLE
Typo in JETBOT_CAMERA environment variable

### DIFF
--- a/docker/jupyter/enable.sh
+++ b/docker/jupyter/enable.sh
@@ -1,5 +1,5 @@
 WORKSPACE=$1
-JETBOT_CAMERA={$2:-opencv_gst_camera}
+JETBOT_CAMERA=${2:-opencv_gst_camera}
 
 # set default swap limit as unlimited
 if [[ -z "$JETBOT_JUPYTER_MEMORY_SWAP" ]]


### PR DESCRIPTION
When using a zmq_camera, it was set to {zmq_camera:-opencv_gst_camera}