### PR TITLE
Missing 'os' import

### DIFF
--- a/jetbot/camera/__init__.py
+++ b/jetbot/camera/__init__.py
@@ -1,8 +1,6 @@
-try:
-    DEFAULT_CAMERA = os.environ['JETBOT_DEFAULT_CAMERA']
-except:
-    DEFAULT_CAMERA = 'opencv_gst_camera'
+import os
 
+DEFAULT_CAMERA = os.environ.get('JETBOT_DEFAULT_CAMERA', 'opencv_gst_camera')
 
 if DEFAULT_CAMERA == 'zmq_camera':
     from .zmq_camera import ZmqCamera


### PR DESCRIPTION
The os import was missing, leading to an exception, so the selected camera was always opencv_gst_camera.
Replaced the try/catch by a get with default.