### PR TITLE
Fix Docker build issue by exporting JETBOT_BASE_IMAGE and take care of L4T 32.5.0/1

### DIFF
--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -15,11 +15,19 @@ then
 elif [[ "$L4T_VERSION" == "32.4.4" ]]
 then
 	JETBOT_BASE_IMAGE=nvcr.io/nvidia/l4t-pytorch:r32.4.4-pth1.6-py3
+elif [[ "$L4T_VERSION" == "32.5.0" ]] || [[ "$L4T_VERSION" == "32.5.1" ]]
+then
+	JETBOT_BASE_IMAGE=nvcr.io/nvidia/l4t-pytorch:r32.5.0-pth1.6-py3
 else
 	echo "JETBOT_BASE_IMAGE not found for ${L4T_VERSION}.  Please manually set the JETBOT_BASE_IMAGE environment variable. (ie: export JETBOT_BASE_IMAGE=...)"
 fi
 
+export JETBOT_BASE_IMAGE
 export JETBOT_DOCKER_REMOTE=jetbot
+
+echo "JETBOT_VERSION=$JETBOT_VERSION"
+echo "L4T_VERSION=$L4T_VERSION"
+echo "JETBOT_BASE_IMAGE=$JETBOT_BASE_IMAGE"
 
 ./set_nvidia_runtime.sh
 sudo systemctl enable docker


### PR DESCRIPTION
Docker build fails on JetPack 4.5.1 (and 4.5).
Fix is to enable JETBOT_BASE_IMAGE by exporting the environmental variable and by defining the base container image for the new JetPack/L4T versions.