### PR TITLE
Removed redundant instruction in live_demo_resnet18_build_trt.ipynb

### DIFF
--- a/notebooks/collision_avoidance/live_demo_resnet18_build_trt.ipynb
+++ b/notebooks/collision_avoidance/live_demo_resnet18_build_trt.ipynb
@@ -123,7 +123,7 @@
    "source": [
     "## Next\n",
     "\n",
-    "Open live_demo_resnet18_build_trt.ipynb to move JetBot with the TensorRT optimized model."
+    <!-- The instruction to open the current file has been removed because it is redundant. -->
    ]
   },
   {


### PR DESCRIPTION
Removed the instruction to open `live_demo_resnet18_build_trt.ipynb` because it is redundant. This file is already open. Requested guidance on what the correct next step should be.