### PR TITLE
Clarify NVIDIA JetBot reference design wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@
 
 <img src="../..//wiki/images/jetson-jetbot-illustration_1600x1260.png" height="256">
 
-JetBot is an open-source robot based on NVIDIA Jetson Nano that is
+JetBot is an open-source robot platform for AI learning and experimentation.
+The original NVIDIA JetBot reference design is an NVIDIA-designed open-source
+robot based on NVIDIA Jetson Nano that is
 
 * **Affordable** - Less than $150 add-on to Jetson Nano
 * **Educational** - Tutorials from basic motion to AI based collision avoidance
 * **Fun!** - Interactively programmed from your web browser
 
 Building and using JetBot gives the hands on experience needed to create entirely new AI projects.
+The broader JetBot ecosystem also includes compatible third party kits such as
+SparkFun JetBot, Waveshare JetBot, and other community or vendor variants.
 
 To get started, read the [JetBot documentation](https://jetbot.org).
 
@@ -24,5 +28,4 @@ We really appreciate any feedback related to JetBot, and also just enjoy seeing 
 * Ask a question and discuss JetBot related topics on the [JetBot GitHub Discussions](https://github.com/NVIDIA-AI-IOT/jetbot/discussions)
 * Report a bug by [creating an issue](https://github.com/NVIDIA-AI-IOT/jetbot/issues)
 * Share your project or ask a question on the [Jetson Developer Forums](https://devtalk.nvidia.com/default/board/139/jetson-embedded-systems/)
-
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,7 +6,7 @@ To get started with JetBot, first pick your vehicle (hardware) you want to make.
 
 ![](images/nvjetbot_vs_3rdparty.png)
 
-For details of NVIDIA-designed open-source JetBot hardware, check [Bill of Materials](bill_of_materials.md) page and [Hardware Setup](hardware_setup.md) page.
+For details of the original NVIDIA JetBot reference design and NVIDIA-designed open-source JetBot hardware, check [Bill of Materials](bill_of_materials.md) page and [Hardware Setup](hardware_setup.md) page.
 
 To find kits available from third parties, check [Third Party Kits](third_party_kits.md) page.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,9 @@
     <a href="getting_started.html" class="md-button md-button--primary">Get Started</a>
 </div>
 
-JetBot is an open-source robot based on NVIDIA Jetson Nano.  You'll like
-it because...
+JetBot is an open-source robot platform for AI learning and experimentation.
+The original NVIDIA JetBot reference design is an NVIDIA-designed open-source
+robot based on NVIDIA Jetson Nano.  You'll like it because...
 
 
 ## It's Affordable
@@ -23,6 +24,8 @@ JetBot costs less than $250 in parts, <i>including</i> Jetson Nano. The DIY kit 
 which you must purchase and a 3D printed chassis that you can print, or order.  If you're looking to get
 up and running as quick as possible, there are also many <a href="third_party_kits.html">third party kits</a> available
 that come pre-bundled.
+These kits are part of the broader JetBot ecosystem and may include compatible
+vendor variants such as SparkFun JetBot and Waveshare JetBot.
 
 
 </div>

--- a/docs/third_party_kits.md
+++ b/docs/third_party_kits.md
@@ -1,6 +1,8 @@
 # Third Party Kits
 
-In addition to the open-source DIY version, several third party JetBot kits using Jetson Nano have emerged.  This page details the kits that we're aware of
+In addition to the open-source DIY version, several third party JetBot kits using Jetson Nano have emerged.  This page details the kits that we're aware of.
+
+JetBot is an open-source robot platform with a broader community and vendor ecosystem.  The original NVIDIA JetBot reference design is the NVIDIA-designed open-source hardware design that many compatible kits build on or adapt.
 
 ???+ note 
     Please note, we do not officially maintain these kits in this GitHub project.  Please refer to the vendor's documentation. Please refer to the vendor URL for cost and availability.  Some kits may have additional vendors that we aren't aware of or haven't listed yet.  If you think these would be helpful for other developers to know, please [let us know](../../issues).
@@ -90,4 +92,3 @@ In addition to the open-source DIY version, several third party JetBot kits usin
 | Kit      | URL |
 |----------|-----|
 | GPUS JetBot Kit (with Jetson Nano Dev Kit) | [Taobao](https://item.taobao.com/item.htm?id=602196310625) |
-


### PR DESCRIPTION
## Summary
- Clarifies JetBot as an open-source robot platform for AI learning and experimentation.
- Identifies the original NVIDIA JetBot reference design as NVIDIA-designed open-source JetBot hardware based on NVIDIA Jetson Nano.
- Preserves the broader JetBot ecosystem framing, including compatible third-party kits such as SparkFun JetBot and Waveshare JetBot.

## Validation
- `mkdocs build` succeeds.
- `mkdocs build --strict` still reports pre-existing documentation warnings unrelated to this copy update, including existing relative-link warnings and the current Material for MkDocs warning.
